### PR TITLE
Add a mark to skip tests that require db

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "db: mark test as needing an database to run"
-    )
+    config.addinivalue_line("markers", "db: mark test as needing an database to run")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
## Summary

Add `@pytest.mark.db` before a test to make it skipable with `pytest --no-db`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If endpoints were changed then they have been documented and tested.
    - [ ] I have updated the docmentation to reflect the changes.
    - [x] I have updated the tests to support the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new endpoint or parameter).
- [ ] This PR is a breaking change (e.g. endpoint or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
