### PR TITLE
added restart always to api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5000:5000"
+    restart: always
     depends_on:
       - db
     links:


### PR DESCRIPTION
## Summary
Just added `restart: always` to docker-compose.yml api service so the db and api service always restart whenever docker does if left started before restarting.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If endpoints were changed then they have been documented and tested.
    - [ ] I have updated the docmentation to reflect the changes.
    - [ ] I have updated the tests to support the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new endpoint or parameter).
- [ ] This PR is a breaking change (e.g. endpoint or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
